### PR TITLE
added security and quality queries to the codeQL config

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -7,4 +7,5 @@ paths-ignore:
   - node_modules
   - python/grass/pygrass/tests
   
-queries: security-and-quality
+queries:
+  - uses: security-and-quality

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -6,3 +6,5 @@ paths-ignore:
   - dist.*
   - node_modules
   - python/grass/pygrass/tests
+  
+queries: security-and-quality


### PR DESCRIPTION
I added a line adding security-quality queries to the codeQL configuration file. This will probably give us more bug reports to sort through, however we can exclude the queries that consistently give us false positives. 